### PR TITLE
Remove obsolete version from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   meilisearch:
     image: getmeili/meilisearch:v1.6


### PR DESCRIPTION
This version is obsolete and I think it serves no use anywhere now.